### PR TITLE
Fix operator name fetcher on Windows

### DIFF
--- a/src/include/migraphx/type_name.hpp
+++ b/src/include/migraphx/type_name.hpp
@@ -34,13 +34,7 @@ template <class PrivateMigraphTypeNameProbe>
 std::string compute_type_name()
 {
     std::string name;
-#ifdef _MSC_VER
-// TODO: does not compile for ihipStream_t from hip/hip_runtime_api.h
-//    name = typeid(PrivateMigraphTypeNameProbe).name();
-//    name = name.substr(7);
-#else
     const char parameter_name[] = "PrivateMigraphTypeNameProbe ="; // NOLINT
-
     name = __PRETTY_FUNCTION__;
 
     auto begin  = name.find(parameter_name) + sizeof(parameter_name);
@@ -50,7 +44,6 @@ std::string compute_type_name()
     auto length = name.find_first_of("];", begin) - begin;
 #endif
     name        = name.substr(begin, length);
-#endif
     return name;
 }
 


### PR DESCRIPTION
When clang is used to compile MIGraphX, the code used to generate the OP Name was working just fine. Hence I've reverted the preprocessor change that would "comment it out".
With this change, 60 (up from 3) out of 104 tests are passing.